### PR TITLE
Convert to idiomatic-gulp approach

### DIFF
--- a/lib/gulp-spritesmith.js
+++ b/lib/gulp-spritesmith.js
@@ -1,7 +1,6 @@
 var assert = require('assert');
 var path = require('path');
-var Readable = require('stream').Readable;
-var Writable = require('stream').Writable;
+var through2 = require('through2');
 var _ = require('underscore');
 var gutil = require('gulp-util');
 var json2css = require('json2css');
@@ -53,11 +52,9 @@ function gulpSpritesmith(params) {
   assert(imgName, 'An `imgName` parameter was not provided to `gulp.spritesmith` (required)');
   assert(cssName, 'A `cssName` parameter was not provided to `gulp.spritesmith` (required)');
 
-
   // Create a stream to take in images
   var images = [];
-  var spriteData = new Writable({objectMode: true});
-  spriteData._write = function (file, encoding, cb) {
+  var onData = function (file, encoding, cb) {
     var filepath = file.path;
     if (filepath) {
       images.push(filepath);
@@ -65,18 +62,8 @@ function gulpSpritesmith(params) {
     cb();
   };
 
-  // Define our output streams
-  spriteData.img = new Readable({objectMode: true});
-  spriteData.img._read = function imgRead () {
-    // Do nothing, let the `finish` handler take care of this
-  };
-  spriteData.css = new Readable({objectMode: true});
-  spriteData.css._read = function cssRead () {
-    // Do nothing, let the `finish` handler take care of this
-  };
-
   // When we have completed our input
-  spriteData.on('finish', function createSprite () {
+  var onEnd = function (cb) {
     // Determine the format of the image
     var imgOpts = params.imgOpts || {};
     var imgFormat = imgOpts.format || imgFormats.get(imgName) || 'png';
@@ -94,18 +81,18 @@ function gulpSpritesmith(params) {
       'engineOpts': params.engineOpts || {},
       'exportOpts': imgOpts
     };
+    var self = this;
     spritesmith(spritesmithParams, function (err, result) {
       // If an error occurred, emit it
       if (err) {
-        return spriteData.emit('error', err);
+        cb(err);
       }
 
       // Otherwise, write out the image
-      spriteData.img.push(new gutil.File({
+      self.push(new gutil.File({
         path: imgName,
         contents: new Buffer(result.image, 'binary')
       }));
-      spriteData.img.push(null);
 
       // START OF BARELY MODIFIED SECTION FROM grunt-spritesmith@1.22.0
       // Generate a listing of CSS variables
@@ -162,16 +149,15 @@ function gulpSpritesmith(params) {
       // END OF BARELY MODIFIED SECTION FROM grunt-spritesmith@1.22.0
 
       // Output the CSS
-      spriteData.css.push(new gutil.File({
+      self.push(new gutil.File({
         path: cssName,
         contents: new Buffer(cssStr)
       }));
-      spriteData.css.push(null);
+      cb();
     });
-  });
+  };
 
-  // Return out input stream with 2 outputs
-  return spriteData;
+  return through2.obj(onData, onEnd);
 }
 
 module.exports = gulpSpritesmith;

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "spritesmith": "~0.19.0",
     "underscore": "~1.6.0",
     "url2": "~1.0.0",
-    "json2css": "~5.2.0"
+    "json2css": "~5.2.0",
+    "through2": "~0.6.1"
   },
   "devDependencies": {
     "mocha": "~1.11.0",


### PR DESCRIPTION
The plugin now returns a single stream instead of two streams.

This fixes two problems:
1. Now the output can be piped into other plugins.
2. In the previous technique gulp can never tell if the task has
   actually completed because it doesn't have a stream to test.
   
   See orchestrator's runTask for more information:
   https://github.com/orchestrator/orchestrator/blob/master/lib/runTask.js
