### PR TITLE
Change image size match assertion to warning

### DIFF
--- a/lib/gulp-spritesmith.js
+++ b/lib/gulp-spritesmith.js
@@ -283,12 +283,13 @@ function gulpSpritesmith(params) {
 
         // Generate groups for our coordinates
         retinaGroups = cleanCoords.map(function getRetinaGroups (normalSprite, i) {
-          // Assert that image sizes line up for debugging purposes
+          // Warn if image sizes do not line up
           var retinaSprite = retinaCleanCoords[i];
-          assert(retinaSprite.width === normalSprite.width * 2 || retinaSprite.height !== normalSprite.height * 2,
-            'Normal sprite has inconsistent size with retina sprite. ' +
+          if (retinaSprite.width !== normalSprite.width * 2 || retinaSprite.height !== normalSprite.height * 2) {
+            console.warn('Warning: Normal sprite has inconsistent size with retina sprite. ' +
             '"' + normalSprite.name + '" is ' + normalSprite.width + 'x' + normalSprite.height + ' while ' +
             '"' + retinaSprite.name + '" is ' + retinaSprite.width + 'x' + retinaSprite.height + '.');
+          }
 
           // Generate our group
           // DEV: Name is inherited from `cssVarMap` on normal sprite


### PR DESCRIPTION
Useful for when the retina icons are odd sized, leading to 1px off normal sizes