### PR TITLE
Wrong checking of retina image size for all dimensions

### DIFF
--- a/lib/gulp-spritesmith.js
+++ b/lib/gulp-spritesmith.js
@@ -285,7 +285,7 @@ function gulpSpritesmith(params) {
         retinaGroups = cleanCoords.map(function getRetinaGroups (normalSprite, i) {
           // Assert that image sizes line up for debugging purposes
           var retinaSprite = retinaCleanCoords[i];
-          assert(retinaSprite.width === normalSprite.width * 2 || retinaSprite.height !== normalSprite.height * 2,
+          assert(retinaSprite.width === normalSprite.width * 2 && retinaSprite.height === normalSprite.height * 2,
             'Normal sprite has inconsistent size with retina sprite. ' +
             '"' + normalSprite.name + '" is ' + normalSprite.width + 'x' + normalSprite.height + ' while ' +
             '"' + retinaSprite.name + '" is ' + retinaSprite.width + 'x' + retinaSprite.height + '.');


### PR DESCRIPTION
We should check both width and height.