### PR TITLE
remove refactor deprecated gulp-util dependency

### DIFF
--- a/lib/gulp-spritesmith.js
+++ b/lib/gulp-spritesmith.js
@@ -4,7 +4,7 @@ var async = require('async');
 var fs = require('fs');
 var path = require('path');
 var _ = require('underscore');
-var gutil = require('gulp-util');
+var Vinyl = require('vinyl');
 var Minimatch = require('minimatch').Minimatch;
 var templater = require('spritesheet-templates');
 var Spritesmith = require('spritesmith');
@@ -377,14 +377,14 @@ function gulpSpritesmith(params) {
       result.image.on('error', function forwardImgError(err) {
         that.emit('error', err);
       });
-      var imgFile = new gutil.File({
+      var imgFile = new Vinyl({
         path: imgName,
         contents: result.image
       });
       that.push(imgFile);
       imgStream.push(imgFile);
       if (retinaResult) {
-        var retinaImgFile = new gutil.File({
+        var retinaImgFile = new Vinyl({
           path: retinaImgName,
           contents: retinaResult.image
         });
@@ -399,7 +399,7 @@ function gulpSpritesmith(params) {
       imgStream.push(null);
 
       // Output the CSS
-      var cssFile = new gutil.File({
+      var cssFile = new Vinyl({
         path: cssName,
         contents: new Buffer(cssStr)
       });

--- a/package.json
+++ b/package.json
@@ -28,13 +28,13 @@
   },
   "dependencies": {
     "async": "~2.1.5",
-    "gulp-util": "~3.0.8",
     "minimatch": "~3.0.3",
     "spritesheet-templates": "~10.2.0",
     "spritesmith": "~3.1.0",
     "through2": "~2.0.3",
     "underscore": "~1.8.3",
-    "url2": "~1.0.4"
+    "url2": "~1.0.4",
+    "vinyl": "~2.1.0"
   },
   "devDependencies": {
     "eslint": "~4.10.0",


### PR DESCRIPTION
Hi,

Since gulp-util has been deprecated, this PR replaces gulp-util with alternative individual modules. https://github.com/gulpjs/gulp-util